### PR TITLE
remove root user dependency and create 00-revocation.list.txt only if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ None
 
     - hosts: pki
       roles:
-         - { role: netzwirt.simple-pki }
+         - { role: jsecchiero.simple-pki }
 
 
 
@@ -104,7 +104,3 @@ git_branch: master
 # License
 
 BSD
-
-# Author Information
-
-[netzwirt](https://github.com/netzwirt)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ Check certificate with crl:
     openssl verify -crl_check_all -verbose -CAfile ca/chained-ca.sha256.2048.crt \
              -CRLfile crl/signing-ca.crl  certs/fred.sha256.2048.crt
 
+## Git sync
+
+for store your pki in a private git repo
+private key enabled to the repo, must be readable
+only from the owner (chmod 400)
+
+```
+git_key: id_rsa
+git_url: github.com/myprofile/myprivaterepo
+git_branch: master
+```
+
 # License
 
 BSD

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -36,7 +36,7 @@
   with_items: simplepki_revocation_list
 
 - name: git push
-  shell: git add . && git commit -m "update keys" && git push
+  shell: git add . && git commit -m "update keys"; git push
   args:
     chdir : "{{ simplepki_base_dir }}"
   environment:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,7 @@
     executable=/bin/bash
   notify:
   - create chained ca file
+  - git push
   with_items:
     - "{{ simplepki_signing_ca_name}}"
     - "{{ simplepki_root_ca_name}}"
@@ -31,4 +32,12 @@
     executable=/bin/bash
   notify:
   - create crls
+  - git push
   with_items: simplepki_revocation_list
+
+- name: git push
+  shell: git add . && git commit -m "update keys" && git push
+  args:
+    chdir : "{{ simplepki_base_dir }}"
+  environment:
+    GIT_KEY: "{{ git_key | realpath }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,5 @@
 ---
 galaxy_info:
-  author: 'Reto Gassmann'
-  description: 'Simple PKI for Ubuntu/Debian'
   license: BSD
   min_ansible_version: '1.8'
 

--- a/tasks/certs.ca.yml
+++ b/tasks/certs.ca.yml
@@ -71,8 +71,8 @@
 - name: protect keys
   file: 
     path: "{{ item }}"
-    owner: root 
-    group: root 
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
     mode: 0400
   with_items:
   - "{{ simplepki_root_ca_private_dir }}/{{ simplepki_root_ca_name }}{{ simplepki_file_ext_key }}"

--- a/tasks/certs.servers.yml
+++ b/tasks/certs.servers.yml
@@ -30,8 +30,8 @@
 - name: protect server keys
   file: 
     path: "{{ simplepki_certs_dir }}/{{ item.fqdn }}{{ simplepki_file_ext_key }}"
-    owner: root 
-    group: root 
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
     mode: 0400
   with_items: "{{ simplepki_server_certs }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
 # tasks file for netzwirt.simple-pki
 
+- name: git pull using the given key
+  git: 
+    accept_hostkey: yes
+    dest: "{{ simplepki_base_dir }}/"
+    key_file: "{{ git_key | realpath }}"
+    repo: "{{ git_url }}"
+    version: "{{ git_branch }}"
+    recursive: yes
+    force: yes
+    update: yes
+
 - include: pki-structure.yml
 - include: ssl-config.yml
 - include: certs.ca.yml
@@ -32,3 +43,10 @@
   notify: [create crls,create chained ca file,revoke certificates]
   when: simplepki_revocation_list|length > 0
 
+- name: git push
+  shell: git add . && git commit -m "update keys" && git push
+  args:
+    chdir : "{{ simplepki_base_dir }}"
+  environment:
+    GIT_KEY: "{{ git_key | realpath }}"
+  register: push

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,4 +30,5 @@
     dest: "{{ simplepki_certs_dir }}/00-revocation.list.txt"
     src: "revocation.list.j2"
   notify: [create crls,create chained ca file,revoke certificates]
+  when: simplepki_revocation_list|length > 0
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   when: simplepki_revocation_list|length > 0
 
 - name: git push
-  shell: git add . && git commit -m "update keys" && git push
+  shell: git add . && git commit -m "update keys"; git push
   args:
     chdir : "{{ simplepki_base_dir }}"
   environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
 # tasks file for netzwirt.simple-pki
 
+- name: copy private key
+  copy: src="{{ git_key | realpath }}" dest="/tmp/simple-pki.tmp" mode=0400
+
 - name: git pull using the given key
   git: 
     accept_hostkey: yes
     dest: "{{ simplepki_base_dir }}/"
-    key_file: "{{ git_key | realpath }}"
+    key_file: "/tmp/simple-pki.tmp"
     repo: "{{ git_url }}"
     version: "{{ git_branch }}"
     recursive: yes
@@ -48,5 +51,9 @@
   args:
     chdir : "{{ simplepki_base_dir }}"
   environment:
-    GIT_KEY: "{{ git_key | realpath }}"
+    GIT_SSH_COMMAND: "/usr/bin/ssh -o StrictHostKeyChecking=no -i /tmp/simple-pki.tmp"
+    GIT_AUTHOR_NAME: "simplepki"
+    GIT_AUTHOR_EMAIL: "secchierojacopo@gmail.com"
+    GIT_COMMITTER_NAME: "simplepki"
+    GIT_COMMITTER_EMAIL: "secchierojacopo@gmail.com"
   register: push

--- a/tasks/pki-structure.yml
+++ b/tasks/pki-structure.yml
@@ -7,7 +7,6 @@
     path: "{{ item }}"
     state: directory 
     mode: 0755 
-    owner: root
   with_items:
     - "{{ simplepki_base_dir }}"
     - "{{ simplepki_ca_base_dir }}"
@@ -21,7 +20,6 @@
     path: "{{ item }}" 
     state: directory 
     mode: 0700 
-    owner: root
   with_items:
     - "{{ simplepki_root_ca_dir }}"
     - "{{ simplepki_root_ca_private_dir }}"


### PR DESCRIPTION
Hi, nice work  with this repo :+1: 

Actually `00-revocation.list.txt` file is created anyway even when `simplepki_renew_certificates` is empty and when `revoke certificates` handler is called the playbook stop with error.

Also the root user should not be a mandatory requirement since a PKI is not strictly related with root user.

Hope this helps.

Jacopo